### PR TITLE
Edited snyk and sonarcloud checks so that they shouldnt do it on prs

### DIFF
--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -21,8 +21,6 @@ name: Snyk Security
 on:
   push:
     branches: ["main" ]
-  pull_request:
-    branches: ["main"]
 
 permissions:
   contents: read

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -31,8 +31,6 @@ name: SonarCloud analysis
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The Snyk and Sonarcloud pull request checks have been failing to run due to the prs being external. THis should hopefully stop these checks from occuring at all

closes #60 