### PR TITLE
Refactor - use money datatype closes #121

### DIFF
--- a/backend/src/config/createTables.js
+++ b/backend/src/config/createTables.js
@@ -23,18 +23,17 @@ const createUserTableQuery = `
     email VARCHAR(255) NOT NULL UNIQUE,
     password VARCHAR(255) NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP , 
-    balance DOUBLE PRECISION DEFAULT 0.0,
-    saving_goal DOUBLE PRECISION DEFAULT 0.0
+    balance NUMERIC(16,2) DEFAULT 0.0 NOT NULL,
+    saving_goal NUMERIC(16,2) DEFAULT 0.0 NOT NULL
 
   );
 `;
-
 const createTransactionTableQuery = `
   CREATE TABLE IF NOT EXISTS transactions (\
     id SERIAL PRIMARY KEY,
     user_id INTEGER NOT NULL,
     title VARCHAR(255) NOT NULL , 
-    amount NUMERIC(10,2) NOT NULL,
+    amount NUMERIC(16,2) NOT NULL,
     description TEXT , 
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE

--- a/backend/src/config/createTables.js
+++ b/backend/src/config/createTables.js
@@ -23,8 +23,8 @@ const createUserTableQuery = `
     email VARCHAR(255) NOT NULL UNIQUE,
     password VARCHAR(255) NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP , 
-    balance NUMERIC(16,2) DEFAULT 0.0 NOT NULL,
-    saving_goal NUMERIC(16,2) DEFAULT 0.0 NOT NULL
+    balance money DEFAULT 0.0 NOT NULL,
+    saving_goal money DEFAULT 0.0 NOT NULL
 
   );
 `;
@@ -33,7 +33,7 @@ const createTransactionTableQuery = `
     id SERIAL PRIMARY KEY,
     user_id INTEGER NOT NULL,
     title VARCHAR(255) NOT NULL , 
-    amount NUMERIC(16,2) NOT NULL,
+    amount money NOT NULL,
     description TEXT , 
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE

--- a/frontend/src/components/AddTransactionButton.jsx
+++ b/frontend/src/components/AddTransactionButton.jsx
@@ -40,13 +40,14 @@ export default function AddTransactionButton() {
       // Update the balance after the transaction is created
 
       // PATCH request to update the balance
-      await axiosInstance.patch("/user/balance", { balance: balance + amount });
-
+      const updateBalance = Number(balance) + Number(amount);
+      await axiosInstance.patch("/user/balance", { balance: updateBalance });
       console.log("Balance updated successfully.");
       setBalance(balance + amount); // Update the balance state in the context
     } catch (error) {
       console.error("Error occurred:", error);
     } finally {
+      console.log("Im at finally");
       setShowForm(false);
     }
   };

--- a/frontend/src/components/AddTransactionButton.jsx
+++ b/frontend/src/components/AddTransactionButton.jsx
@@ -40,7 +40,7 @@ export default function AddTransactionButton() {
       // Update the balance after the transaction is created
 
       // PATCH request to update the balance
-      const updateBalance = Number(balance) + Number(amount);
+      const updateBalance = Number(balance) + Number(amount); // use Number() for strings
       await axiosInstance.patch("/user/balance", { balance: updateBalance });
       console.log("Balance updated successfully.");
       setBalance(balance + amount); // Update the balance state in the context

--- a/frontend/src/components/CurrentBalance.jsx
+++ b/frontend/src/components/CurrentBalance.jsx
@@ -18,7 +18,7 @@ export default function CurrentBalance() {
   return (
     <div className="flex flex-col items-center">
       <h2 className="text-sub-heading font-extrabold">
-        Current Balance: ${convertedAmount}
+        Current Balance: {convertedAmount} 
       </h2>
     </div>
   );


### PR DESCRIPTION
- use money datatypes for monetary data in Postgresql
- change amount, balance, saving_goal to money datatype (was Numeric(10,2) and float8)
- money can store from -92233720368547758.08 to +92233720368547758.07
- need to change frontend to allow only up to 2 decimal points when adding transactions