### PR TITLE
only allow transaction amount that aligns with the database

### DIFF
--- a/frontend/src/components/TransactionForm.jsx
+++ b/frontend/src/components/TransactionForm.jsx
@@ -36,6 +36,41 @@ export default function TransactionForm({ onSubmit, onCancel }) {
     }
   }, [transactionType, title, amount]);
 
+  const handleAmountChange = (e) => {
+    let value = e.target.value;
+
+    if (value === "") {
+      setAmount("");
+      return;
+    }
+
+    // Split into integer and decimal parts
+    const [integerPart, decimalPart] = value.split(".");
+    
+    // the below comment is required for the BigInt working
+    /* global BigInt */
+    try {
+      // Check if the integer part exceeds the allowed digits (14 digits)
+      const integerBigInt = BigInt(integerPart);
+      if (integerBigInt > BigInt("99999999999999") || integerBigInt < BigInt("-99999999999999")) {
+        alert("Amount must be between -99,999,999,999,999.99 and +99,999,999,999,999.99.");
+        return;
+      }
+
+      // Handle decimal part (ensure it is not more than 2 decimal places)
+      if (decimalPart && decimalPart.length > 2) {
+        alert("Amount cannot have more than 2 decimal places.");
+        return;
+      }
+
+      // If valid, set the amount
+      setAmount(value);
+    } catch (error) {
+      alert("Please enter a valid number.");
+    }
+  };
+
+
   // Prevent form submission on enter key press
   const handleKeyDown = (event) => {
     if (event.key === "Enter") {
@@ -122,13 +157,8 @@ export default function TransactionForm({ onSubmit, onCancel }) {
             <input
               type="number"
               id="amount"
-
-              
               value={amount}
-              
-              onChange={(e) => {setAmount(e.target.value)}
-              }
-
+              onChange={handleAmountChange}
               onKeyDown={handleKeyDown}
               className={inputStyle}
             ></input>


### PR DESCRIPTION
- users can only input transaction amount that aligns with the database, Numeric(16,2)
- When  the value exceeds the range, an alert will pop up with instructions
  - no more than 14 integer part
  - no more than 2 decimal part
- use BigInt so that the comparison does not lose precision